### PR TITLE
add play_sound example

### DIFF
--- a/examples/use_inside_gme/play_sound/Makefile
+++ b/examples/use_inside_gme/play_sound/Makefile
@@ -1,0 +1,8 @@
+all:
+	# use gcc with optimization level -O1
+	arm-none-eabi-gcc -O1 -T ../../tiptoi.ld -nostdlib main.c -I ../../include -o main.o
+	arm-none-eabi-objdump -d main.o
+	arm-none-eabi-objcopy -O binary main.o out.bin
+
+clean:
+	rm -f *.o *.elf *.bin *.s

--- a/examples/use_inside_gme/play_sound/main.c
+++ b/examples/use_inside_gme/play_sound/main.c
@@ -1,0 +1,29 @@
+typedef void code();
+typedef int func();
+
+void main(int *param_1)
+{
+
+    char (*isAudioPlaying)(void) = (void *)*(param_1 + 3);
+
+    if (isAudioPlaying() == 0)
+    {
+        int offsetPointer34 = *(param_1 + 13);
+        int someOffset = **(int **)(param_1 + 14);
+        int var;
+        int copyOfVar;
+        int soundId;
+        soundId = *(char *)(offsetPointer34 + 0x1320);
+        // soundId = 42;
+
+        (**(code **)(param_1 + 9))(someOffset, 4, 0);
+        (**(code **)(param_1 + 6))(someOffset, &var, 4);
+        (**(code **)(param_1 + 9))(someOffset, var + soundId * 8, 0);
+        (**(code **)(param_1 + 6))(someOffset, &var, 4);
+        copyOfVar = var;
+        (**(code **)(param_1 + 6))(someOffset, &var, 4);
+        (**(code **)(param_1 + 11))(**(int **)(param_1 + 14), copyOfVar, var);
+
+        *(char *)(offsetPointer34 + 0x1320) = (*(char *)(offsetPointer34 + 0x1320)) + 1; // counts up 
+    }
+}


### PR DESCRIPTION
Plays all audio files in the gme file. Works on ZC3202N and ZC3203L.